### PR TITLE
Create label-merge-conflicts.yml

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The typical use case is to run this action post merge (e.g. push to master) to quickly see which other PRs are now in conflict.

About me
GSSoC aspirant.